### PR TITLE
Just crash unpack job if unpack fails

### DIFF
--- a/lib/Cavil/Checkout.pm
+++ b/lib/Cavil/Checkout.pm
@@ -151,7 +151,7 @@ sub unpack {
   my $err = $@ || ($u->{error} ? join(', ', @{$u->{error}}) : undef);
 
   if ($err) {
-    -f $log ? warn $err : die $err;
+    die $err;
     return;
   }
 


### PR DESCRIPTION
Half unpacked packages just crash children jobs and we can't see why