### PR TITLE
A reimport task got suddenly quite useful over the weekend

### DIFF
--- a/lib/Cavil.pm
+++ b/lib/Cavil.pm
@@ -130,7 +130,8 @@ sub startup {
       state $pkgs = Cavil::Model::Packages->new(
         checkout_dir => $config->{checkout_dir},
         minion       => $self->minion,
-        pg           => shift->pg
+        pg           => shift->pg,
+        log          => $self->log
       );
     }
   );


### PR DESCRIPTION
Unfortunately it requires more work - as often the infos in bot_sources
are outdated. So for a useful reimport we need to dig for the verifymd5
in all known products. for the weekend incident I did just that as I only
needed to restore those actually in products.

My aim was actually reimporting past reviews, but that is much harder