### PR TITLE
Combine the risk 9 avoidance patch with basic tests

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -2,7 +2,7 @@
 -nst     # support multiple files
 -w       # Show all warnings
 -iob     # Ignore old breakpoints
--l=80    # 80 characters per line
+-l=120   # 120 characters per line
 -mbl=2   # No more than 2 blank lines
 -i=2     # Indentation is 2 columns
 -ci=2    # Continuation indentation is 2 columns

--- a/lib/Cavil/Controller/License.pm
+++ b/lib/Cavil/Controller/License.pm
@@ -65,9 +65,10 @@ sub edit_pattern {
 
   my $result = $bag->best_for($pattern->{pattern}, 2);
   my $best   = $result->[0];
-  if ($best->{pattern} == $id) {    # likely perfect match
-    $best = $result->[1];
-  }
+
+  # likely perfect match
+  $best = $result->[1] if $best->{pattern} && $best->{pattern} == $id;
+
   my $sim = $best->{match};
   $best = $self->patterns->find($best->{pattern});
 

--- a/lib/Cavil/Model/Packages.pm
+++ b/lib/Cavil/Model/Packages.pm
@@ -50,7 +50,7 @@ sub actions {
   my ($self, $link, $id) = @_;
 
   # Requests with multiple actions are an OBS thing
-  return [] unless $link =~ /^obs#/ || $link =~ /^ibs#/;
+  return [] if !$link || !($link =~ /^obs#/ || $link =~ /^ibs#/);
 
   return $self->pg->db->query(
     "select p.id, p.name, result, state, login,

--- a/lib/Cavil/Task/Analyze.pm
+++ b/lib/Cavil/Task/Analyze.pm
@@ -225,7 +225,16 @@ sub _shortname {
   for my $risk (keys %{$report->{risks}}) {
     $max_risk = $risk if $risk > $max_risk;
   }
-  $max_risk = 9 if %{$report->{missed_snippets}};
+  if (defined $report->{missed_files}) {
+    for my $file (keys %{$report->{missed_files}}) {
+      my $risk = $report->{missed_files}{$file}[0];
+      $max_risk = $risk if $risk > $max_risk;
+    }
+  }
+  else {
+    # old style
+    $max_risk = 9 if %{$report->{missed_snippets}};
+  }
 
   my $l = lic($specfile->{main}{license})->example;
   $l ||= 'Error';

--- a/lib/Cavil/Task/ClosestMatch.pm
+++ b/lib/Cavil/Task/ClosestMatch.pm
@@ -42,8 +42,7 @@ sub _pattern_stats {
   $bag->dump($cache);
   rename($cache, $app->home->child('cache', 'cavil.pattern.bag'));
 
-  $rows
-    = $db->select('snippets', 'id,text', {license => 1, like_pattern => undef});
+  $rows = $db->select('snippets', 'id,text', {like_pattern => undef});
   while (my $next = $rows->hash) {
     my $best_pattern = $bag->best_for($next->{text}, 1)->[0];
     $db->update(

--- a/lib/Cavil/Task/ClosestMatch.pm
+++ b/lib/Cavil/Task/ClosestMatch.pm
@@ -37,8 +37,24 @@ sub _pattern_stats {
   my %patterns;
   $patterns{$_->{id}} = $_->{pattern} for $rows->each;
   $bag->set_patterns(\%patterns);
-  my $cache = $app->home->child('cache', 'cavil.pattern.bag');
+
+  my $cache = $app->home->child('cache', 'cavil.pattern.bag.new.' . $job->id);
   $bag->dump($cache);
+  rename($cache, $app->home->child('cache', 'cavil.pattern.bag'));
+
+  $rows
+    = $db->select('snippets', 'id,text', {license => 1, like_pattern => undef});
+  while (my $next = $rows->hash) {
+    my $best_pattern = $bag->best_for($next->{text}, 1)->[0];
+    $db->update(
+      'snippets',
+      {
+        likelyness   => $best_pattern->{match},
+        like_pattern => $best_pattern->{pattern},
+      },
+      {id => $next->{id}}
+    );
+  }
 }
 
 1;

--- a/migrations/cavil.sql
+++ b/migrations/cavil.sql
@@ -253,3 +253,11 @@ create table ignored_files (
 
 -- 10 down
 drop table if exists ignored_files;
+
+-- 11 up
+alter table snippets add likelyness real not null default 0;
+alter table snippets add like_pattern int references license_patterns(id) on delete set null;
+
+-- 11 down
+alter table drop column likelyness, drop column like_pattern;
+

--- a/t/index.t
+++ b/t/index.t
@@ -282,7 +282,6 @@ $t->app->minion->perform_jobs;
 
 # Accepted because of low risk
 $pkg = $t->app->packages->find($pkg_id);
-
 is $pkg->{state}, 'acceptable', 'automatically accepted';
 is $pkg->{result}, 'Accepted because of low risk (5)', 'because of low risk';
 

--- a/t/manual_review.t
+++ b/t/manual_review.t
@@ -102,6 +102,29 @@ subtest 'Details after import (with login)' => sub {
 $t->app->minion->enqueue(unpack => [$pkg_id]);
 $t->app->minion->perform_jobs;
 
+subtest 'Snippets after indexing' => sub {
+  my $snippets = $t->app->pg->db->select('snippets')->hashes->to_array;
+  is $snippets->[0]{id},           1,     'snippet';
+  is $snippets->[0]{like_pattern}, undef, 'unlike any pattern';
+  ok !$snippets->[0]{likelyness}, 'no likelyness';
+  is $snippets->[1]{id},           2,     'snippet';
+  is $snippets->[1]{like_pattern}, undef, 'unlike any pattern';
+  ok !$snippets->[1]{likelyness}, 'no likelyness';
+  is $snippets->[2]{id},           3,     'snippet';
+  is $snippets->[2]{like_pattern}, undef, 'unlike any pattern';
+  ok !$snippets->[2]{likelyness}, 'no likelyness';
+  is $snippets->[3]{id},           4,     'snippet';
+  is $snippets->[3]{like_pattern}, undef, 'unlike any pattern';
+  ok !$snippets->[3]{likelyness}, 'no likelyness';
+  is $snippets->[4]{id},           5,     'snippet';
+  is $snippets->[4]{like_pattern}, undef, 'unlike any pattern';
+  ok !$snippets->[4]{likelyness}, 'no likelyness';
+  is $snippets->[5]{id},           6,     'snippet';
+  is $snippets->[5]{like_pattern}, undef, 'unlike any pattern';
+  ok !$snippets->[5]{likelyness}, 'no likelyness';
+  is $snippets->[6], undef, 'no more snippets';
+};
+
 subtest 'Details after indexing' => sub {
   $t->get_ok('/login')->status_is(302)->header_is(Location => '/');
 
@@ -125,6 +148,29 @@ $t->app->minion->enqueue('pattern_stats');
 $t->app->minion->perform_jobs;
 $t->app->packages->reindex($pkg_id);
 $t->app->minion->perform_jobs;
+
+subtest 'Snippets after reindexing' => sub {
+  my $snippets = $t->app->pg->db->select('snippets')->hashes->to_array;
+  is $snippets->[0]{id},           1, 'snippet';
+  is $snippets->[0]{like_pattern}, 6, 'like pattern';
+  ok $snippets->[0]{likelyness} > 0, 'likelyness';
+  is $snippets->[1]{id},           2, 'snippet';
+  is $snippets->[1]{like_pattern}, 1, 'like pattern';
+  ok $snippets->[1]{likelyness} > 0, 'likelyness';
+  is $snippets->[2]{id},           3, 'snippet';
+  is $snippets->[2]{like_pattern}, 5, 'like pattern';
+  ok $snippets->[2]{likelyness} > 0, 'likelyness';
+  is $snippets->[3]{id},           4, 'snippet';
+  is $snippets->[3]{like_pattern}, 5, 'like pattern';
+  ok $snippets->[3]{likelyness} > 0, 'likelyness';
+  is $snippets->[4]{id},           5, 'snippet';
+  is $snippets->[4]{like_pattern}, 2, 'like pattern';
+  ok $snippets->[4]{likelyness} > 0, 'likelyness';
+  is $snippets->[5]{id},           6, 'snippet';
+  is $snippets->[5]{like_pattern}, 6, 'like pattern';
+  ok $snippets->[5]{likelyness} > 0, 'likelyness';
+  is $snippets->[6], undef, 'no more snippets';
+};
 
 subtest 'Details after reindexing' => sub {
   $t->get_ok('/login')->status_is(302)->header_is(Location => '/');

--- a/t/manual_review.t
+++ b/t/manual_review.t
@@ -1,0 +1,187 @@
+use Mojo::Base -strict;
+
+BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
+
+use Test::More;
+
+plan skip_all => 'set TEST_ONLINE to enable this test' unless $ENV{TEST_ONLINE};
+
+use Test::Mojo;
+use Mojo::File qw(path tempdir);
+use Mojo::Pg;
+use Mojolicious::Lite;
+
+# Isolate tests
+my $pg = Mojo::Pg->new($ENV{TEST_ONLINE});
+$pg->db->query('drop schema if exists analyze_test cascade');
+$pg->db->query('create schema analyze_test');
+
+# Create checkout directory
+my $dir  = tempdir;
+my @src  = ('perl-Mojolicious', 'c7cfdab0e71b0bebfdf8b2dc3badfecd');
+my $mojo = $dir->child(@src)->make_path;
+$_->copy_to($mojo->child($_->basename)) for path(__FILE__)->dirname->child('legal-bot', @src)->list->each;
+@src  = ('perl-Mojolicious', 'da3e32a3cce8bada03c6a9d63c08cd58');
+$mojo = $dir->child(@src)->make_path;
+$_->copy_to($mojo->child($_->basename)) for path(__FILE__)->dirname->child('legal-bot', @src)->list->each;
+
+app->log->level('error');
+
+# Configure application
+my $online = Mojo::URL->new($ENV{TEST_ONLINE})->query([search_path => 'analyze_test'])->to_unsafe_string;
+my $config = {
+  secrets                => ['just_a_test'],
+  checkout_dir           => $dir,
+  tokens                 => [],
+  pg                     => $online,
+  acceptable_risk        => 3,
+  index_bucket_average   => 100,
+  cleanup_bucket_average => 50,
+  min_files_short_report => 20,
+  max_email_url_size     => 26,
+  max_task_memory        => 5_000_000_000,
+  max_worker_rss         => 100000,
+  max_expanded_files     => 100
+};
+my $t = Test::Mojo->new(Cavil => $config);
+$t->app->pg->migrations->migrate;
+
+# Prepare database
+my $db     = $t->app->pg->db;
+my $usr_id = $db->insert('bot_users', {login => 'test_bot'}, {returning => 'id'})->hash->{id};
+my $pkg_id = $t->app->packages->add(
+  name            => 'perl-Mojolicious',
+  checkout_dir    => 'c7cfdab0e71b0bebfdf8b2dc3badfecd',
+  api_url         => 'https://api.opensuse.org',
+  requesting_user => $usr_id,
+  project         => 'devel:languages:perl',
+  package         => 'perl-Mojolicious',
+  srcmd5          => 'bd91c36647a5d3dd883d490da2140401',
+  priority        => 5
+);
+$t->app->packages->imported($pkg_id);
+$t->app->patterns->create(pattern => 'You may obtain a copy of the License at', license => 'Apache-2.0');
+$t->app->patterns->create(
+  packname => 'perl-Mojolicious',
+  pattern  => 'Licensed under the Apache License, Version 2.0',
+  license  => 'Apache-2.0'
+);
+$t->app->patterns->create(pattern => 'License: Artistic-2.0', license => 'Artistic-2.0');
+$t->app->patterns->create(pattern => 'License: GPL-1.0+',     license => 'GPL-1.0+');
+$t->app->patterns->create(pattern => 'License: GPL-1.0+',     license => 'GPL-1.0+');
+$t->app->patterns->create(pattern => 'the terms',             risk    => 9);
+$t->app->patterns->create(pattern => 'copyright notice',      risk    => 9);
+
+subtest 'Details after import (indexing in progress)' => sub {
+  $t->get_ok('/reviews/details/1')->status_is(200)->text_like('#rpm-license', qr!Artistic-2.0!)
+    ->text_like('#rpm-version', qr!7\.25!)->text_like('#rpm-summary', qr!Real-time web framework!)
+    ->text_like('#rpm-group',   qr!Development/Libraries/Perl!)
+    ->text_like('#rpm-url a',   qr!http://search\.cpan\.org/dist/Mojolicious/!)->text_like('#pkg-state', qr!new!)
+    ->element_exists_not('#pkg-review')->element_exists_not('#pkg-shortname')
+    ->element_exists_not('#pkg-review label[for=comment]')->element_exists_not('#pkg-review textarea[name=comment]')
+    ->element_exists_not('#correct')->element_exists_not('#acceptable')->element_exists_not('#unacceptable');
+  $t->get_ok('/reviews/calc_report/1')->status_is(408);
+};
+
+subtest 'Details after import (with login)' => sub {
+  $t->get_ok('/login')->status_is(302)->header_is(Location => '/');
+
+  $t->get_ok('/reviews/details/1')->status_is(200)->text_like('#rpm-license', qr!Artistic-2.0!)
+    ->text_like('#rpm-version', qr!7\.25!)->text_like('#rpm-summary', qr!Real-time web framework!)
+    ->text_like('#rpm-group',   qr!Development/Libraries/Perl!)
+    ->text_like('#rpm-url a',   qr!http://search\.cpan\.org/dist/Mojolicious/!)->text_like('#pkg-state', qr!new!)
+    ->element_exists('#pkg-review')->element_exists_not('#pkg-shortname')
+    ->element_exists('#pkg-review label[for=comment]')->element_exists('#pkg-review textarea[name=comment]')
+    ->element_exists('#correct')->element_exists('#acceptable')->element_exists('#unacceptable');
+  $t->get_ok('/reviews/calc_report/1')->status_is(408);
+
+  $t->get_ok('/logout')->status_is(302)->header_is(Location => '/');
+};
+
+# Unpack and index
+$t->app->minion->enqueue(unpack => [$pkg_id]);
+$t->app->minion->perform_jobs;
+
+subtest 'Details after indexing' => sub {
+  $t->get_ok('/login')->status_is(302)->header_is(Location => '/');
+
+  $t->get_ok('/reviews/details/1')->status_is(200)->text_like('#rpm-license', qr!Artistic-2.0!)
+    ->text_like('#rpm-version', qr!7\.25!)->text_like('#rpm-summary', qr!Real-time web framework!)
+    ->text_like('#rpm-group',   qr!Development/Libraries/Perl!)
+    ->text_like('#rpm-url a',   qr!http://search\.cpan\.org/dist/Mojolicious/!)->text_like('#pkg-state', qr!new!)
+    ->element_exists('#pkg-review')->element_exists('#pkg-shortname')->element_exists('#pkg-review label[for=comment]')
+    ->element_exists('#pkg-review textarea[name=comment]')->element_exists('#correct')->element_exists('#acceptable')
+    ->element_exists('#unacceptable');
+
+  $t->get_ok('/reviews/calc_report/1')->status_is(200)->element_exists('#license-chart')->element_exists('#emails')
+    ->text_like('#emails tbody td', qr!coolo\@suse\.com!)->element_exists('#urls')
+    ->text_like('#urls tbody td',   qr!http://mojolicious.org!);
+
+  $t->get_ok('/logout')->status_is(302)->header_is(Location => '/');
+};
+
+# Reindex (with updated stats)
+$t->app->minion->enqueue('pattern_stats');
+$t->app->minion->perform_jobs;
+$t->app->packages->reindex($pkg_id);
+$t->app->minion->perform_jobs;
+
+subtest 'Details after reindexing' => sub {
+  $t->get_ok('/login')->status_is(302)->header_is(Location => '/');
+
+  $t->get_ok('/reviews/details/1')->status_is(200)->text_like('#rpm-license', qr!Artistic-2.0!)
+    ->text_like('#rpm-version', qr!7\.25!)->text_like('#rpm-summary', qr!Real-time web framework!)
+    ->text_like('#rpm-group',   qr!Development/Libraries/Perl!)
+    ->text_like('#rpm-url a',   qr!http://search\.cpan\.org/dist/Mojolicious/!)->text_like('#pkg-state', qr!new!)
+    ->element_exists('#pkg-review')->element_exists('#pkg-shortname')->element_exists('#pkg-review label[for=comment]')
+    ->element_exists('#pkg-review textarea[name=comment]')->element_exists('#correct')->element_exists('#acceptable')
+    ->element_exists('#unacceptable');
+
+  $t->get_ok('/reviews/calc_report/1')->status_is(200)->element_exists('#license-chart')
+    ->element_exists('#unmatched-files')->text_is('#unmatched-count', '4')
+    ->text_like('#unmatched-files li:nth-of-type(1) a', qr!Mojolicious-7.25/Changes!)
+    ->text_like('#unmatched-files li:nth-of-type(1)',   qr!100% Snippet - estimated risk 9!)
+    ->text_like('#unmatched-files li:nth-of-type(2) a', qr!Mojolicious-7.25/LICENSE!)
+    ->text_like('#unmatched-files li:nth-of-type(2)',   qr![0-9.]+% Snippet - estimated risk 9!)
+    ->text_like('#unmatched-files li:nth-of-type(3) a', qr!perl-Mojolicious\.changes!)
+    ->text_like('#unmatched-files li:nth-of-type(3)',   qr!100% Snippet - estimated risk 9!)
+    ->text_like('#unmatched-files li:nth-of-type(4) a', qr!Mojolicious-7.25/lib/Mojolicious.pm!)
+    ->text_like('#unmatched-files li:nth-of-type(4)',   qr![0-9.]+% Apache-2.0 - estimated risk 7!)
+    ->element_exists('#risk-5')->text_like('#risk-5 li', qr!Apache-2.0!)
+    ->text_like('#risk-5 li ul li:nth-of-type(1) a', qr!Mojolicious-7.25/lib/Mojolicious.pm!)
+    ->text_like('#risk-5 li ul li:nth-of-type(2) a', qr!Mojolicious-7.25/lib/Mojolicious/resources/public/!);
+  $t->element_exists('#emails')->text_like('#emails tbody td', qr!coolo\@suse\.com!)->element_exists('#urls')
+    ->text_like('#urls tbody td', qr!http://mojolicious.org!);
+
+  $t->get_ok('/logout')->status_is(302)->header_is(Location => '/');
+};
+
+subtest 'Manual review' => sub {
+  $t->get_ok('/login')->status_is(302)->header_is(Location => '/');
+
+  $t->post_ok('/reviews/review_package/1' => form => {comment => 'Test review', acceptable => 'Good Enough'})
+    ->status_is(200)->text_like('#content a', qr!perl-Mojolicious!)->text_like('#content b', qr!acceptable!);
+
+  $t->get_ok('/reviews/details/1')->status_is(200)->text_like('#rpm-license', qr!Artistic-2.0!)
+    ->text_like('#rpm-version', qr!7\.25!)->text_like('#rpm-summary', qr!Real-time web framework!)
+    ->text_like('#rpm-group',   qr!Development/Libraries/Perl!)
+    ->text_like('#rpm-url a',   qr!http://search\.cpan\.org/dist/Mojolicious/!)->text_like('#pkg-state', qr!acceptable!)
+    ->element_exists('#pkg-review')->element_exists('#pkg-shortname')->element_exists('#pkg-review label[for=comment]')
+    ->element_exists('#pkg-review textarea[name=comment]')->element_exists('#correct')->element_exists('#acceptable')
+    ->element_exists('#unacceptable');
+
+  $t->get_ok('/reviews/calc_report/1')->status_is(200)->element_exists('#license-chart')
+    ->element_exists('#unmatched-files')->text_is('#unmatched-count', '4')
+    ->text_like('#unmatched-files li:nth-of-type(4) a', qr!Mojolicious-7.25/lib/Mojolicious.pm!)
+    ->text_like('#unmatched-files li:nth-of-type(4)', qr!57% Apache-2.0 - estimated risk 7!)->element_exists('#risk-5');
+  $t->element_exists('#emails')->text_like('#emails tbody td', qr!coolo\@suse\.com!)->element_exists('#urls')
+    ->text_like('#urls tbody td', qr!http://mojolicious.org!);
+
+  $t->get_ok('/logout')->status_is(302)->header_is(Location => '/');
+};
+
+# Clean up once we are done
+$pg->db->query('drop schema analyze_test cascade');
+
+done_testing;
+

--- a/t/manual_review.t
+++ b/t/manual_review.t
@@ -202,8 +202,8 @@ subtest 'Snippets after reindexing' => sub {
   is $snippets->[0]{id},           1, 'snippet';
   is $snippets->[0]{like_pattern}, 6, 'like pattern';
   ok $snippets->[0]{likelyness} > 0, 'likelyness';
-  is $snippets->[1]{id},           2, 'snippet';
-  is $snippets->[1]{like_pattern}, 1, 'like pattern';
+  is $snippets->[1]{id}, 2, 'snippet';
+  ok $snippets->[1]{like_pattern}, 'like pattern (ambiguous... could be 1 or 6)';
   ok $snippets->[1]{likelyness} > 0, 'likelyness';
   is $snippets->[2]{id},           3, 'snippet';
   is $snippets->[2]{like_pattern}, 5, 'like pattern';

--- a/templates/reviewer/details.html.ep
+++ b/templates/reviewer/details.html.ep
@@ -25,7 +25,7 @@
           <i class="fas fa-box"></i>
         </th>
         <th class="fit text-left noleftpad" scope="row">RPM License:</th>
-        <td><%= $lstr %></td>
+        <td id="rpm-license"><%= $lstr %></td>
       </tr>
     % }
 
@@ -71,7 +71,7 @@
           <i class="fas fa-code-branch"></i>
         </th>
         <th class="fit text-left noleftpad" scope="row">Version:</th>
-        <td><%= $version %></td>
+        <td id="rpm-version"><%= $version %></td>
       </tr>
     % }
 
@@ -81,7 +81,7 @@
           <i class="fas fa-edit"></i>
         </th>
         <th class="fit text-left noleftpad" scope="row">Summary:</th>
-        <td><%= $summary %></td>
+        <td id="rpm-summary"><%= $summary %></td>
       </tr>
     % }
 
@@ -91,7 +91,7 @@
           <i class="fas fa-users"></i>
         </th>
         <th class="fit text-left noleftpad" scope="row">Group:</th>
-        <td><%= $group %></td>
+        <td id="rpm-group"><%= $group %></td>
       </tr>
     % }
 
@@ -101,7 +101,7 @@
           <i class="fas fa-link"></i>
         </th>
         <th class="fit text-left noleftpad" scope="row">URL:</th>
-        <td><%= link_to $url => $url => (target => '_blank') %></td>
+        <td id="rpm-url"><%= link_to $url => $url => (target => '_blank') %></td>
       </tr>
     % }
 
@@ -112,7 +112,7 @@
           <i class="far fa-file"></i>
         </th>
         <th class="fit text-left noleftpad" scope="row">Shortname:</th>
-        <td><%= $shortname %></td>
+        <td id="pkg-shortname"><%= $shortname %></td>
       </tr>
     % }
 
@@ -149,7 +149,7 @@
         <i class="fas fa-balance-scale"></i>
       </th>
       <th class="fit text-left noleftpad" scope="row">State:</th>
-      <td><%= $package->{state} %></td>
+      <td id="pkg-state"><%= $package->{state} %></td>
     </tr>
 
     % if (@$history) {
@@ -237,7 +237,7 @@
 
 % if (current_user_has_role 'admin') {
     <div class="row">
-        %= form_for review_package => (class => 'container') => begin
+        %= form_for review_package => (class => 'container', id => 'pkg-review') => begin
             <div class="form-group">
                 <label for="comment">Comment:</label>
                 <textarea name="comment" class="form-control"><%= $package->{result} // 'Reviewed ok' %></textarea>

--- a/templates/reviewer/report.html.ep
+++ b/templates/reviewer/report.html.ep
@@ -16,22 +16,22 @@
   <canvas id="license-chart" width="100%" height="18em"></canvas>
 
   % my %linked_files;
-  % if (%{$report->{missed_snippets}}) {
+  % if (@{$report->{missed_files}}) {
     <div class="alert alert-warning" role="alert">
-      Found unmatched keywords in (at least) <span class="badge badge-secondary"><%= scalar keys %{$report->{missed_snippets}} %></span> files.
+      Found unmatched keywords in (at least) <span class="badge badge-secondary"><%= scalar @{$report->{missed_files}} %></span> files.
       License report is incomplete
 
       <div id="filelist-snippets" class="collapse show">
         <ul>
-        % for my $name (sort keys %{$report->{missed_snippets}}) {
-          % my ($id, $snippet_infos) = @{$report->{missed_snippets}->{$name}};
+        % for my $file (@{$report->{missed_files}}) {
           <li>
-            <a href="#file-<%= $id %>" class="file-link"
-              data-file="<%= $id %>">
-              %= $name
+            <a href="#file-<%= $file->{id} %>" class="file-link"
+              data-file="<%= $file->{id} %>">
+              %= $file->{name}
             </a>
+            %= "($file->{match}% $file->{license} - estimated risk $file->{max_risk})"
           </li>
-          % $linked_files{$id} = 1;
+          % $linked_files{$file->{id}} = 1;
         % }
         </ul>
       </div>

--- a/templates/reviewer/report.html.ep
+++ b/templates/reviewer/report.html.ep
@@ -17,8 +17,8 @@
 
   % my %linked_files;
   % if (@{$report->{missed_files}}) {
-    <div class="alert alert-warning" role="alert">
-      Found unmatched keywords in (at least) <span class="badge badge-secondary"><%= scalar @{$report->{missed_files}} %></span> files.
+    <div id="unmatched-files" class="alert alert-warning" role="alert">
+      Found unmatched keywords in (at least) <span id="unmatched-count" class="badge badge-secondary"><%= scalar @{$report->{missed_files}} %></span> files.
       License report is incomplete
 
       <div id="filelist-snippets" class="collapse show">
@@ -45,7 +45,7 @@
     <h3>Risk <%= $risk %></h3>
     % my $current = $risks->{$risk};
 
-    <ul>
+    <ul id="risk-<%= $risk %>">
       % for my $lic (sort keys %$current) {
         % my $matches = $current->{$lic};
         % my $name = $matches->{name};


### PR DESCRIPTION
This is an expanded version of #39 with basic test coverage for the feature (and for our standard manual review process... which also still has dangerously low coverage).

As a followup, I'd really like to rewrite our code for bootstrapping a fresh Cavil instance (which is currently broken due to patches applied in the previous year that made significant changes to the data model). And then use those bootstrap patterns to make more involved test cases with many more matches and licenses. It would be quite labour intensive, but the Cavil code also keeps getting much more complex, and i fear the technical debt will crush us at some point.