### PR TITLE
let CodeMirror use full size on file view

### DIFF
--- a/assets/legacy/file.js
+++ b/assets/legacy/file.js
@@ -2,4 +2,5 @@ import CodeMirror from 'codemirror';
 
 export function setupCodeMirrorForFile() {
   window.cavil.myCodeMirror = CodeMirror.fromTextArea(document.getElementById('file'), {theme: 'neo'});
+  window.cavil.myCodeMirror.setSize('auto', 'auto');
 }


### PR DESCRIPTION
textarea of CodeMirror for file view is too small and should therefore be resized to 100%. 